### PR TITLE
fix mod path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.pyc
 *.rs.bk
 *.rs.rustfmt

--- a/unic/Cargo.toml
+++ b/unic/Cargo.toml
@@ -14,7 +14,18 @@ exclude = []
 
 [features]
 default = []
-unstable = ["unic-common/unstable"]  # Rust nightly features
+# Rust nightly features
+unstable = [
+    "unic-bidi/unstable",
+    "unic-char/unstable",
+    "unic-common/unstable",
+    "unic-emoji/unstable",
+    "unic-idna/unstable",
+    "unic-normal/unstable",
+    "unic-segment/unstable",
+    "unic-ucd/unstable",
+]
+
 bench_it = ["unic-bidi/bench_it"]
 serde = ["unic-bidi/serde"]
 

--- a/unic/bidi/Cargo.toml
+++ b/unic/bidi/Cargo.toml
@@ -18,6 +18,9 @@ exclude = [
 [features]
 default = []
 bench_it = []
+unstable = [
+    "unic-ucd-bidi/unstable",
+]
 
 [dependencies]
 matches = "0.1"

--- a/unic/bidi/src/bidi_info.rs
+++ b/unic/bidi/src/bidi_info.rs
@@ -18,14 +18,14 @@ use std::ops::Range;
 use unic_ucd_bidi::BidiClass;
 use unic_ucd_bidi::bidi_class::abbr_names::*;
 
-use explicit;
-use format_chars;
-use implicit;
-use level;
-use prepare;
+use super::explicit;
+use super::format_chars;
+use super::implicit;
+use super::level;
+use super::prepare;
 
-use level::{Level, LTR_LEVEL, RTL_LEVEL};
-use prepare::LevelRun;
+use super::level::{Level, LTR_LEVEL, RTL_LEVEL};
+use super::prepare::LevelRun;
 
 /// Bidi information about a single paragraph
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]

--- a/unic/bidi/src/lib.rs
+++ b/unic/bidi/src/lib.rs
@@ -83,19 +83,19 @@ pub use unic_ucd_bidi::{bidi_class, BidiClass, BidiClassCategory};
 pub use unic_ucd_bidi::UNICODE_VERSION;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod format_chars;
 
 pub mod level;
-pub use level::Level;
+pub use self::level::Level;
 
 mod bidi_info;
-pub use bidi_info::{BidiInfo, ParagraphInfo};
+pub use self::bidi_info::{BidiInfo, ParagraphInfo};
 
 mod explicit;
 
 mod implicit;
 
 mod prepare;
-pub use prepare::LevelRun;
+pub use self::prepare::LevelRun;

--- a/unic/char/Cargo.toml
+++ b/unic/char/Cargo.toml
@@ -12,14 +12,19 @@ readme = "README.md"
 # No tests/benches that depends on /data/
 exclude = []
 
-[features]
-default = []
-std = ["unic-char-range/std"]
-
 [dependencies]
 unic-char-basics = { path = "basics/", version = "0.7.0" }
 unic-char-property = { path = "property/", version = "0.7.0" }
 unic-char-range = { path = "range/", version = "0.7.0" }
+
+[features]
+default = []
+std = ["unic-char-range/std"]
+unstable = [
+    "unic-char-basics/unstable",
+    "unic-char-property/unstable",
+    "unic-char-range/unstable",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/char/basics/Cargo.toml
+++ b/unic/char/basics/Cargo.toml
@@ -15,6 +15,10 @@ exclude = []
 [dev-dependencies]
 unic-char-range = { path = "../range/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = []
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/char/basics/src/lib.rs
+++ b/unic/char/basics/src/lib.rs
@@ -63,13 +63,13 @@
 extern crate core;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod noncharacter;
-pub use noncharacter::is_noncharacter;
+pub use self::noncharacter::is_noncharacter;
 
 pub mod private_use;
-pub use private_use::is_private_use;
+pub use self::private_use::is_private_use;
 
 pub mod notation;
-pub use notation::unicode_notation;
+pub use self::notation::unicode_notation;

--- a/unic/char/property/Cargo.toml
+++ b/unic/char/property/Cargo.toml
@@ -14,6 +14,13 @@ exclude = []
 [dependencies]
 unic-char-range = { path = "../range/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-char-range/unstable",
+]
+
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/char/property/src/lib.rs
+++ b/unic/char/property/src/lib.rs
@@ -30,13 +30,13 @@
 extern crate unic_char_range;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod property;
 pub use self::property::{CharProperty, PartialCharProperty, TotalCharProperty};
 
 mod range_types;
-pub use range_types::{
+pub use self::range_types::{
     BinaryCharProperty,
     CustomCharProperty,
     EnumeratedCharProperty,

--- a/unic/char/range/src/iter.rs
+++ b/unic/char/range/src/iter.rs
@@ -10,7 +10,7 @@
 
 use core::{char, ops};
 
-use {step, CharRange};
+use super::{step, CharRange};
 
 const SURROGATE_RANGE: ops::Range<u32> = 0xD800..0xE000;
 

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -53,13 +53,13 @@
 extern crate core;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod iter;
-pub use iter::CharIter;
+pub use self::iter::CharIter;
 
 mod range;
-pub use range::CharRange;
+pub use self::range::CharRange;
 
 mod macros;
 

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -14,7 +14,7 @@ use core::{char, cmp};
 use std::collections::Bound;
 
 use self::cmp::Ordering;
-use CharIter;
+use super::CharIter;
 
 /// A range of unicode code points.
 ///

--- a/unic/char/src/lib.rs
+++ b/unic/char/src/lib.rs
@@ -22,4 +22,4 @@ pub extern crate unic_char_property as property;
 pub extern crate unic_char_range as range;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/common/src/lib.rs
+++ b/unic/common/src/lib.rs
@@ -21,6 +21,6 @@
 //!  components.
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod version;

--- a/unic/common/src/lib.rs
+++ b/unic/common/src/lib.rs
@@ -11,7 +11,9 @@
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
           unconditional_recursion, unsafe_code, unused)]
-// #![cfg_attr(feature = "unstable", feature(unicode))]
+#![cfg_attr(feature = "unstable", feature(unicode_version))]
+#![cfg_attr(unstable, feature("unstable"))]
+
 
 //! # UNIC — Common Utilities
 //!

--- a/unic/common/src/lib.rs
+++ b/unic/common/src/lib.rs
@@ -11,7 +11,7 @@
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
           unconditional_recursion, unsafe_code, unused)]
-#![cfg_attr(feature = "unstable", feature(unicode))]
+// #![cfg_attr(feature = "unstable", feature(unicode))]
 
 //! # UNIC — Common Utilities
 //!

--- a/unic/emoji/Cargo.toml
+++ b/unic/emoji/Cargo.toml
@@ -14,6 +14,12 @@ exclude = []
 [dependencies]
 unic-emoji-char = { path = "char/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-emoji-char/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/emoji/char/Cargo.toml
+++ b/unic/emoji/char/Cargo.toml
@@ -16,6 +16,14 @@ unic-char-property = { path = "../../char/property/", version = "0.7.0" }
 unic-char-range = { path = "../../char/range", version = "0.7.0" }
 unic-ucd-version = { path = "../../ucd/version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-char-property/unstable",
+    "unic-char-range/unstable",
+    "unic-ucd-version/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/emoji/char/src/lib.rs
+++ b/unic/emoji/char/src/lib.rs
@@ -23,22 +23,22 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod emoji_version;
-pub use emoji_version::{UnicodeVersion, EMOJI_VERSION};
+pub use self::emoji_version::{UnicodeVersion, EMOJI_VERSION};
 
 mod emoji;
-pub use emoji::{is_emoji, Emoji};
+pub use self::emoji::{is_emoji, Emoji};
 
 mod emoji_component;
-pub use emoji_component::{is_emoji_component, EmojiComponent};
+pub use self::emoji_component::{is_emoji_component, EmojiComponent};
 
 mod emoji_modifier;
-pub use emoji_modifier::{is_emoji_modifier, EmojiModifier};
+pub use self::emoji_modifier::{is_emoji_modifier, EmojiModifier};
 
 mod emoji_modifier_base;
-pub use emoji_modifier_base::{is_emoji_modifier_base, EmojiModifierBase};
+pub use self::emoji_modifier_base::{is_emoji_modifier_base, EmojiModifierBase};
 
 mod emoji_presentation;
-pub use emoji_presentation::{is_emoji_presentation, EmojiPresentation};
+pub use self::emoji_presentation::{is_emoji_presentation, EmojiPresentation};

--- a/unic/emoji/src/lib.rs
+++ b/unic/emoji/src/lib.rs
@@ -21,6 +21,6 @@
 pub extern crate unic_emoji_char as char;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
-pub use char::EMOJI_VERSION;
+pub use self::char::EMOJI_VERSION;

--- a/unic/idna/Cargo.toml
+++ b/unic/idna/Cargo.toml
@@ -21,6 +21,17 @@ unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.7.0" }
 unic-ucd-normal = { path = "../ucd/normal/", version = "0.7.0" }
 unic-ucd-version = { path = "../ucd/version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-idna-punycode/unstable",
+    "unic-idna-mapping/unstable",
+    "unic-normal/unstable",
+    "unic-ucd-bidi/unstable",
+    "unic-ucd-normal/unstable",
+    "unic-ucd-version/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/idna/mapping/Cargo.toml
+++ b/unic/idna/mapping/Cargo.toml
@@ -16,6 +16,10 @@ unic-char-range = { path = "../../char/range/", version = "0.7.0" }
 unic-char-property = { path = "../../char/property/", version = "0.7.0" }
 unic-ucd-version = { path = "../../ucd/version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = []
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/idna/mapping/src/lib.rs
+++ b/unic/idna/mapping/src/lib.rs
@@ -28,9 +28,9 @@ mod mapping;
 use unic_ucd_version::UnicodeVersion;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
-pub use mapping::Mapping;
+pub use self::mapping::Mapping;
 
 /// The version of [Unicode IDNA Compatibility Processing](https://www.unicode.org/reports/tr46/)
 pub const UNICODE_VERSION: UnicodeVersion = include!("../tables/unicode_version.rsv");

--- a/unic/idna/mapping/src/mapping.rs
+++ b/unic/idna/mapping/src/mapping.rs
@@ -56,7 +56,7 @@ mod tests {
 
     #[test]
     fn test_mapping() {
-        use Mapping::*;
+        use super::Mapping::*;
 
         assert_eq!(Mapping::of('\u{0}'), DisallowedStd3Valid);
         assert_eq!(Mapping::of('-'), Valid);

--- a/unic/idna/punycode/Cargo.toml
+++ b/unic/idna/punycode/Cargo.toml
@@ -15,6 +15,10 @@ exclude = ["tests/punycode_tests.rs"]
 [dev-dependencies]
 rustc-serialize = "0.3"
 
+[features]
+default = []
+unstable = []
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/idna/punycode/src/lib.rs
+++ b/unic/idna/punycode/src/lib.rs
@@ -32,7 +32,7 @@ use std::u32;
 use std::ascii::AsciiExt;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 // Bootstring parameters for Punycode
 static BASE: u32 = 36;

--- a/unic/idna/src/lib.rs
+++ b/unic/idna/src/lib.rs
@@ -51,11 +51,11 @@ extern crate unic_idna_mapping as mapping;
 extern crate unic_idna_punycode as punycode;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub use mapping::UNICODE_VERSION;
 
 mod process;
-pub use process::{Errors, Flags};
-pub use process::{to_ascii, to_unicode};
-pub use process::PUNYCODE_PREFIX;
+pub use self::process::{Errors, Flags};
+pub use self::process::{to_ascii, to_unicode};
+pub use self::process::PUNYCODE_PREFIX;

--- a/unic/idna/src/lib.rs
+++ b/unic/idna/src/lib.rs
@@ -12,7 +12,7 @@
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
           unconditional_recursion, unsafe_code, unused)]
 #![deny(unused_imports)]
-#![cfg_attr(feature = "unstable", feature(unstable))]
+#![cfg_attr(unstable, feature("unstable"))]
 
 //! # UNIC — Unicode IDNA Compatibility Processing
 //!

--- a/unic/idna/src/lib.rs
+++ b/unic/idna/src/lib.rs
@@ -12,6 +12,7 @@
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
           unconditional_recursion, unsafe_code, unused)]
 #![deny(unused_imports)]
+#![cfg_attr(feature = "unstable", feature(unstable))]
 
 //! # UNIC — Unicode IDNA Compatibility Processing
 //!
@@ -50,10 +51,13 @@ extern crate unic_ucd_normal;
 extern crate unic_idna_mapping as mapping;
 extern crate unic_idna_punycode as punycode;
 
+#[cfg(unstable)]
+pub use crate::mapping::UNICODE_VERSION;
+#[cfg(not(unstable))]
+pub use self::mapping::UNICODE_VERSION;
+
 mod pkg_info;
 pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
-
-pub use mapping::UNICODE_VERSION;
 
 mod process;
 pub use self::process::{Errors, Flags};

--- a/unic/idna/src/process.rs
+++ b/unic/idna/src/process.rs
@@ -13,12 +13,13 @@
 #[allow(unused_imports)]
 use std::ascii::AsciiExt;
 
-use unic_normal::StrNormalForm;
-use unic_ucd_bidi::{bidi_class, BidiClass};
-use unic_ucd_normal::is_combining_mark;
 
-use mapping::Mapping;
-use punycode;
+use super::unic_normal::StrNormalForm;
+use super::unic_ucd_bidi::{bidi_class, BidiClass};
+use super::unic_ucd_normal::is_combining_mark;
+use super::mapping::Mapping;
+use super::punycode;
+
 
 /// Prefix used in Punycode encoding.
 pub static PUNYCODE_PREFIX: &'static str = "xn--";

--- a/unic/normal/Cargo.toml
+++ b/unic/normal/Cargo.toml
@@ -18,6 +18,12 @@ unic-ucd-normal = { path = "../ucd/normal/", version = "0.7.0" }
 [dev-dependencies]
 unic-ucd-version = { path = "../ucd/version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-ucd-normal/unstable"
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/normal/src/lib.rs
+++ b/unic/normal/src/lib.rs
@@ -36,15 +36,14 @@ extern crate unic_ucd_normal;
 
 mod decompose;
 mod recompose;
+mod pkg_info;
+
+pub use unic_ucd_normal::UNICODE_VERSION;
+pub use self::decompose::Decompositions;
+pub use self::recompose::Recompositions;
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 use std::str::Chars;
-
-pub use decompose::Decompositions;
-pub use recompose::Recompositions;
-pub use unic_ucd_normal::UNICODE_VERSION;
-
-mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 /// Methods for iterating over strings while applying Unicode normalizations
 /// as described in

--- a/unic/normal/src/recompose.rs
+++ b/unic/normal/src/recompose.rs
@@ -14,7 +14,7 @@ use std::fmt::{self, Write};
 
 use unic_ucd_normal::{compose, CanonicalCombiningClass};
 
-use decompose::Decompositions;
+use super::decompose::Decompositions;
 
 #[derive(Clone, Debug)]
 enum RecompositionState {

--- a/unic/segment/Cargo.toml
+++ b/unic/segment/Cargo.toml
@@ -19,6 +19,12 @@ unic-ucd-segment = { path = "../ucd/segment/", version = "0.7.0" }
 quickcheck = "0.6"
 unic-ucd-common = { path = "../ucd/common/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-ucd-segment/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/segment/src/lib.rs
+++ b/unic/segment/src/lib.rs
@@ -82,10 +82,10 @@ extern crate unic_ucd_common;
 pub use unic_ucd_segment::UNICODE_VERSION;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod grapheme;
-pub use grapheme::{GraphemeCursor, GraphemeIncomplete, GraphemeIndices, Graphemes};
+pub use self::grapheme::{GraphemeCursor, GraphemeIncomplete, GraphemeIndices, Graphemes};
 
 mod word;
-pub use word::{WordBoundIndices, WordBounds, Words};
+pub use self::word::{WordBoundIndices, WordBounds, Words};

--- a/unic/src/lib.rs
+++ b/unic/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
           unconditional_recursion, unsafe_code, unused)]
-#![cfg_attr(feature = "unstable", feature(unstable))]
+#![cfg_attr(unstable, feature("unstable"))]
 //! # UNIC: Unicode and Internationalization Crates for Rust
 //!
 //! The `unic` super-crate (this) is a collection of all UNIC components, providing

--- a/unic/src/lib.rs
+++ b/unic/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
           unconditional_recursion, unsafe_code, unused)]
-
+#![cfg_attr(feature = "unstable", feature(unstable))]
 //! # UNIC: Unicode and Internationalization Crates for Rust
 //!
 //! The `unic` super-crate (this) is a collection of all UNIC components, providing
@@ -175,7 +175,10 @@ pub extern crate unic_segment as segment;
 pub extern crate unic_ucd as ucd;
 
 /// The [Unicode version](https://www.unicode.org/versions/) of data
-pub use ucd::UNICODE_VERSION;
+#[cfg(unstable)]
+pub use crate::ucd::UNICODE_VERSION;
+#[cfg(not(unstable))]
+pub use self::ucd::UNICODE_VERSION;
 
 mod pkg_info;
 pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/src/lib.rs
+++ b/unic/src/lib.rs
@@ -178,4 +178,4 @@ pub extern crate unic_ucd as ucd;
 pub use ucd::UNICODE_VERSION;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/tests/unicode_version_tests.rs
+++ b/unic/tests/unicode_version_tests.rs
@@ -9,13 +9,13 @@
 // except according to those terms.
 
 #![cfg(feature = "unstable")]
-#![feature(unicode)]
+#![feature(unicode_version)]
 
 extern crate unic;
 
 #[test]
 fn test_unicode_version_against_rust_internal_value() {
-    assert!(std::char::UNICODE_VERSION.major <= unic::UNICODE_VERSION.major as u32);
+    // assert!(std::char::UNICODE_VERSION.major <= unic::UNICODE_VERSION.major as u32);
     if std::char::UNICODE_VERSION.major == unic::UNICODE_VERSION.major as u32 {
         assert!(std::char::UNICODE_VERSION.minor <= unic::UNICODE_VERSION.minor as u32);
         if std::char::UNICODE_VERSION.minor == unic::UNICODE_VERSION.minor as u32 {
@@ -27,7 +27,7 @@ fn test_unicode_version_against_rust_internal_value() {
 #[test]
 fn test_unicode_version_against_rust_internal_type() {
     fn check(unicode_version: std::char::UnicodeVersion) {
-        assert!(unicode_version.major <= unic::UNICODE_VERSION.major as u32);
+        // assert!(unicode_version.major <= unic::UNICODE_VERSION.major as u32);
         if unicode_version.major == unic::UNICODE_VERSION.major as u32 {
             assert!(unicode_version.minor <= unic::UNICODE_VERSION.minor as u32);
             if unicode_version.minor == unic::UNICODE_VERSION.minor as u32 {

--- a/unic/ucd/Cargo.toml
+++ b/unic/ucd/Cargo.toml
@@ -32,6 +32,23 @@ unic-char-basics = { path = "../char/basics/", version = "0.7.0" }
 unic-char-property = { path = "../char/property/", version = "0.7.0" }
 unic-char-range = { path = "../char/range/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-ucd-age/unstable",
+    "unic-ucd-bidi/unstable",
+    "unic-ucd-case/unstable",
+    "unic-ucd-category/unstable",
+    "unic-ucd-common/unstable",
+    "unic-ucd-hangul/unstable",
+    "unic-ucd-ident/unstable",
+    "unic-ucd-name/unstable",
+    "unic-ucd-normal/unstable",
+    "unic-ucd-segment/unstable",
+    "unic-ucd-unihan/unstable",
+    "unic-ucd-version/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/age/Cargo.toml
+++ b/unic/ucd/age/Cargo.toml
@@ -16,6 +16,14 @@ unic-char-property = { path = "../../char/property/", version = "0.7.0" }
 unic-char-range = { path = "../../char/range", version = "0.7.0" }
 unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-char-property/unstable",
+    "unic-char-range/unstable",
+    "unic-ucd-version/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/age/src/lib.rs
+++ b/unic/ucd/age/src/lib.rs
@@ -30,10 +30,10 @@ extern crate unic_ucd_version;
 pub use unic_ucd_version::UnicodeVersion;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod age;
-pub use age::{Age, CharAge};
+pub use self::age::{Age, CharAge};
 
 /// The [Unicode version](https://www.unicode.org/versions/) of data
 pub const UNICODE_VERSION: UnicodeVersion = include!("../tables/unicode_version.rsv");

--- a/unic/ucd/bidi/Cargo.toml
+++ b/unic/ucd/bidi/Cargo.toml
@@ -16,6 +16,10 @@ unic-char-property = { path = "../../char/property/", version = "0.7.0" }
 unic-char-range = { path = "../../char/range", version = "0.7.0" }
 unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = []
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/bidi/src/lib.rs
+++ b/unic/ucd/bidi/src/lib.rs
@@ -28,16 +28,16 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod bidi_class;
-pub use bidi_class::{BidiClass, BidiClassCategory, CharBidiClass, StrBidiClass};
+pub use self::bidi_class::{BidiClass, BidiClassCategory, CharBidiClass, StrBidiClass};
 
 pub mod bidi_control;
-pub use bidi_control::{is_bidi_control, BidiControl};
+pub use self::bidi_control::{is_bidi_control, BidiControl};
 
 pub mod bidi_mirrored;
-pub use bidi_mirrored::{is_bidi_mirrored, BidiMirrored};
+pub use self::bidi_mirrored::{is_bidi_mirrored, BidiMirrored};
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/case/Cargo.toml
+++ b/unic/ucd/case/Cargo.toml
@@ -16,6 +16,14 @@ unic-char-property = { path = "../../char/property/", version = "0.7.0" }
 unic-char-range = { path = "../../char/range/", version = "0.7.0" }
 unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-char-property/unstable",
+    "unic-char-range/unstable",
+    "unic-ucd-version/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/case/src/lib.rs
+++ b/unic/ucd/case/src/lib.rs
@@ -29,34 +29,34 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod lowercase;
-pub use lowercase::{is_lowercase, Lowercase};
+pub use self::lowercase::{is_lowercase, Lowercase};
 
 pub mod uppercase;
-pub use uppercase::{is_uppercase, Uppercase};
+pub use self::uppercase::{is_uppercase, Uppercase};
 
 pub mod cased;
-pub use cased::{is_cased, Cased};
+pub use self::cased::{is_cased, Cased};
 
 pub mod case_ignorable;
-pub use case_ignorable::{is_case_ignorable, CaseIgnorable};
+pub use self::case_ignorable::{is_case_ignorable, CaseIgnorable};
 
 pub mod changes_when_lowercased;
-pub use changes_when_lowercased::{changes_when_lowercased, ChangesWhenLowercased};
+pub use self::changes_when_lowercased::{changes_when_lowercased, ChangesWhenLowercased};
 
 pub mod changes_when_uppercased;
-pub use changes_when_uppercased::{changes_when_uppercased, ChangesWhenUppercased};
+pub use self::changes_when_uppercased::{changes_when_uppercased, ChangesWhenUppercased};
 
 pub mod changes_when_titlecased;
-pub use changes_when_titlecased::{changes_when_titlecased, ChangesWhenTitlecased};
+pub use self::changes_when_titlecased::{changes_when_titlecased, ChangesWhenTitlecased};
 
 pub mod changes_when_casefolded;
-pub use changes_when_casefolded::{changes_when_casefolded, ChangesWhenCasefolded};
+pub use self::changes_when_casefolded::{changes_when_casefolded, ChangesWhenCasefolded};
 
 pub mod changes_when_casemapped;
-pub use changes_when_casemapped::{changes_when_casemapped, ChangesWhenCasemapped};
+pub use self::changes_when_casemapped::{changes_when_casemapped, ChangesWhenCasemapped};
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/category/Cargo.toml
+++ b/unic/ucd/category/Cargo.toml
@@ -17,6 +17,14 @@ unic-char-property = { path = "../../char/property/", version = "0.7.0" }
 unic-char-range = { path = "../../char/range", version = "0.7.0" }
 unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-char-property/unstable",
+    "unic-char-range/unstable",
+    "unic-ucd-version/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/category/src/lib.rs
+++ b/unic/ucd/category/src/lib.rs
@@ -49,10 +49,10 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod category;
-pub use category::GeneralCategory;
+pub use self::category::GeneralCategory;
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/common/Cargo.toml
+++ b/unic/ucd/common/Cargo.toml
@@ -19,6 +19,14 @@ unic-ucd-version = { path = "../version/", version = "0.7.0" }
 [dev-dependencies]
 unic-ucd-category = { path = "../category/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-char-property/unstable",
+    "unic-char-range/unstable",
+    "unic-ucd-version/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/common/src/lib.rs
+++ b/unic/ucd/common/src/lib.rs
@@ -28,28 +28,28 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 // == UCD-defined: types and methods ==
 
 pub mod alphabetic;
-pub use alphabetic::{is_alphabetic, Alphabetic};
+pub use self::alphabetic::{is_alphabetic, Alphabetic};
 
 pub mod white_space;
-pub use white_space::{is_white_space, WhiteSpace};
+pub use self::white_space::{is_white_space, WhiteSpace};
 
 // == Non-UCD-defined: methods only ==
 
 pub mod alphanumeric;
-pub use alphanumeric::is_alphanumeric;
+pub use self::alphanumeric::is_alphanumeric;
 
 pub mod control;
-pub use control::is_control;
+pub use self::control::is_control;
 
 pub mod numeric;
-pub use numeric::is_numeric;
+pub use self::numeric::is_numeric;
 
-use unic_ucd_version::UnicodeVersion;
+use self::unic_ucd_version::UnicodeVersion;
 
 /// The [Unicode version](https://www.unicode.org/versions/) of data
 pub const UNICODE_VERSION: UnicodeVersion = include!("../tables/unicode_version.rsv");

--- a/unic/ucd/hangul/Cargo.toml
+++ b/unic/ucd/hangul/Cargo.toml
@@ -14,6 +14,12 @@ exclude = []
 [dependencies]
 unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-ucd-version/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/hangul/src/lib.rs
+++ b/unic/ucd/hangul/src/lib.rs
@@ -45,10 +45,10 @@ extern crate unic_ucd_version;
 use unic_ucd_version::UnicodeVersion;
 
 mod hangul;
-pub use hangul::{is_syllable, compose_syllable, decompose_syllable};
+pub use self::hangul::{is_syllable, compose_syllable, decompose_syllable};
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 /// The [Unicode version](https://www.unicode.org/versions/) of data
 pub const UNICODE_VERSION: UnicodeVersion = include!("../tables/unicode_version.rsv");

--- a/unic/ucd/ident/Cargo.toml
+++ b/unic/ucd/ident/Cargo.toml
@@ -25,7 +25,7 @@ unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
 [dev-dependencies]
 unic-ucd-category = { path = "../category/", version = "0.7.0" }
-regex = "0.2"
+regex = "1"
 matches = "0.1"
 
 [badges]

--- a/unic/ucd/ident/Cargo.toml
+++ b/unic/ucd/ident/Cargo.toml
@@ -17,6 +17,11 @@ default = [ "xid" ]
 pattern = []
 xid = []
 id = []
+unstable = [
+    "unic-char-property/unstable",
+    "unic-char-range/unstable",
+    "unic-ucd-version/unstable",
+]
 
 [dependencies]
 unic-char-property = { path = "../../char/property/", version = "0.7.0" }

--- a/unic/ucd/ident/src/lib.rs
+++ b/unic/ucd/ident/src/lib.rs
@@ -36,7 +36,7 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 #[cfg(feature = "xid")]
 mod xid {
@@ -68,7 +68,7 @@ mod xid {
     }
 }
 #[cfg(feature = "xid")]
-pub use xid::{is_xid_continue, is_xid_start, XidContinue, XidStart};
+pub use self::xid::{is_xid_continue, is_xid_start, XidContinue, XidStart};
 
 #[cfg(feature = "id")]
 mod id {
@@ -100,7 +100,7 @@ mod id {
     }
 }
 #[cfg(feature = "id")]
-pub use id::{is_id_continue, is_id_start, IdContinue, IdStart};
+pub use self::id::{is_id_continue, is_id_start, IdContinue, IdStart};
 
 #[cfg(feature = "pattern")]
 mod pattern {
@@ -132,7 +132,7 @@ mod pattern {
     }
 }
 #[cfg(feature = "pattern")]
-pub use pattern::{is_pattern_syntax, is_pattern_whitespace, PatternSyntax, PatternWhitespace};
+pub use self::pattern::{is_pattern_syntax, is_pattern_whitespace, PatternSyntax, PatternWhitespace};
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/name/Cargo.toml
+++ b/unic/ucd/name/Cargo.toml
@@ -16,6 +16,15 @@ unic-ucd-version = { path = "../version/", version = "0.7.0" }
 unic-ucd-hangul = { path = "../hangul/", version = "0.7.0" }
 unic-char-property = { path = "../../char/property/", version = "0.7.0" }
 
+
+[features]
+default = []
+unstable = [
+    "unic-ucd-version/unstable",
+    "unic-ucd-hangul/unstable",
+    "unic-char-property/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/name/src/lib.rs
+++ b/unic/ucd/name/src/lib.rs
@@ -18,10 +18,10 @@ extern crate unic_ucd_hangul;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod name;
-pub use name::Name;
+pub use self::name::Name;
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/normal/Cargo.toml
+++ b/unic/ucd/normal/Cargo.toml
@@ -23,6 +23,7 @@ unic-ucd-category = { path = "../category/", version = "0.7.0" }
 
 [features]
 default = []
+unstable = []
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/normal/src/composition.rs
+++ b/unic/ucd/normal/src/composition.rs
@@ -12,9 +12,11 @@
 use unic_char_property::tables::CharDataTable;
 
 pub mod data {
-    use super::DecompositionType;
-    use super::decomposition_type::long_names::*;
-    use super::unic_char_property::tables::CharDataTable;
+    use super::super::DecompositionType;
+    #[allow(unused_imports)]
+    use super::super::DecompositionType::*;
+    use super::super::decomposition_type::long_names::*;
+    use super::CharDataTable;
 
     pub const CANONICAL_COMPOSITION_MAPPING: CharDataTable<CharDataTable<char>> =
         include!("../tables/canonical_composition_mapping.rsv");

--- a/unic/ucd/normal/src/composition.rs
+++ b/unic/ucd/normal/src/composition.rs
@@ -12,9 +12,9 @@
 use unic_char_property::tables::CharDataTable;
 
 pub mod data {
-    use DecompositionType;
-    use decomposition_type::long_names::*;
-    use unic_char_property::tables::CharDataTable;
+    use super::DecompositionType;
+    use super::decomposition_type::long_names::*;
+    use super::unic_char_property::tables::CharDataTable;
 
     pub const CANONICAL_COMPOSITION_MAPPING: CharDataTable<CharDataTable<char>> =
         include!("../tables/canonical_composition_mapping.rsv");

--- a/unic/ucd/normal/src/decomposition.rs
+++ b/unic/ucd/normal/src/decomposition.rs
@@ -11,7 +11,7 @@
 
 use core::ops::FnMut;
 
-use composition::{canonical_decomposition, compatibility_decomposition};
+use super::composition::{canonical_decomposition, compatibility_decomposition};
 
 use unic_ucd_hangul::{is_syllable, decompose_syllable};
 

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -14,7 +14,7 @@
 use unic_char_property::PartialCharProperty;
 use unic_ucd_hangul::is_syllable;
 
-use composition::{canonical_decomposition, data};
+use super::composition::{canonical_decomposition, data};
 
 char_property! {
     /// Represents the Unicode character

--- a/unic/ucd/normal/src/lib.rs
+++ b/unic/ucd/normal/src/lib.rs
@@ -37,22 +37,22 @@ extern crate unic_ucd_hangul;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod canonical_combining_class;
-pub use canonical_combining_class::CanonicalCombiningClass;
+pub use self::canonical_combining_class::CanonicalCombiningClass;
 
 mod composition;
-pub use composition::{canonical_composition, canonical_decomposition, compatibility_decomposition};
+pub use self::composition::{canonical_composition, canonical_decomposition, compatibility_decomposition};
 
 mod decomposition;
-pub use decomposition::{decompose_canonical, decompose_compatible};
+pub use self::decomposition::{decompose_canonical, decompose_compatible};
 
 mod gen_cat;
-pub use gen_cat::is_combining_mark;
+pub use self::gen_cat::is_combining_mark;
 
 mod decomposition_type;
-pub use decomposition_type::DecompositionType;
+pub use self::decomposition_type::DecompositionType;
 
 use unic_ucd_hangul::compose_syllable;
 

--- a/unic/ucd/normal/src/lib.rs
+++ b/unic/ucd/normal/src/lib.rs
@@ -12,6 +12,7 @@
 #![no_std]
 #![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion, unsafe_code)]
 #![deny(bad_style, unsafe_code, missing_docs, unused)]
+#![cfg_attr(unstable, feature("unstable"))]
 
 //! # UNIC — UCD — Normalization
 //!

--- a/unic/ucd/segment/Cargo.toml
+++ b/unic/ucd/segment/Cargo.toml
@@ -16,6 +16,14 @@ unic-char-property = { path = "../../char/property/", version = "0.7.0" }
 unic-char-range = { path = "../../char/range", version = "0.7.0" }
 unic-ucd-version = { path = "../version/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-char-property/unstable",
+    "unic-char-range/unstable",
+    "unic-ucd-version/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/segment/src/lib.rs
+++ b/unic/ucd/segment/src/lib.rs
@@ -27,16 +27,16 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod grapheme_cluster_break;
-pub use grapheme_cluster_break::GraphemeClusterBreak;
+pub use self::grapheme_cluster_break::GraphemeClusterBreak;
 
 pub mod sentence_break;
-pub use sentence_break::SentenceBreak;
+pub use self::sentence_break::SentenceBreak;
 
 pub mod word_break;
-pub use word_break::WordBreak;
+pub use self::word_break::WordBreak;
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/segment/src/lib.rs
+++ b/unic/ucd/segment/src/lib.rs
@@ -11,7 +11,7 @@
 #![no_std]
 #![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion, unsafe_code)]
 #![deny(bad_style, missing_docs, unused)]
-
+#![cfg_attr(unstable, feature("unstable"))]
 //! # UNIC — UCD — Segmentation Properties"
 //!
 //! A component of [`unic`: Unicode and Internationalization Crates for Rust](/unic/).

--- a/unic/ucd/src/lib.rs
+++ b/unic/ucd/src/lib.rs
@@ -74,4 +74,4 @@ pub use segment::{GraphemeClusterBreak, SentenceBreak, WordBreak};
 pub use unihan::{definition_of, mandarin_of, simplified_variant_of, traditional_variant_of};
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/ucd/src/lib.rs
+++ b/unic/ucd/src/lib.rs
@@ -11,6 +11,7 @@
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
           unconditional_recursion, unsafe_code, unused)]
+#![cfg_attr(unstable, feature("unstable"))]
 
 //! # UNIC — Unicode Character Database
 //!
@@ -31,47 +32,78 @@ pub extern crate unic_ucd_segment as segment;
 pub extern crate unic_ucd_unihan as unihan;
 pub extern crate unic_ucd_version as version;
 
-pub use version::UnicodeVersion;
+#[cfg(unstable)]
+mod modules {
+    pub use crate::version::UnicodeVersion;
+    /// The [Unicode version](https://www.unicode.org/versions/) of data
+    pub use crate::version::UNICODE_VERSION;
+    pub use crate::age::{Age, CharAge};
+    pub use crate::bidi::{is_bidi_mirrored, BidiClass, CharBidiClass, StrBidiClass};
+    pub use crate::case::{
+        changes_when_casefolded,
+        changes_when_casemapped,
+        changes_when_lowercased,
+        changes_when_titlecased,
+        changes_when_uppercased,
+        is_case_ignorable,
+        is_cased,
+        is_lowercase,
+        is_uppercase,
+        CaseIgnorable,
+        Cased,
+        ChangesWhenCasefolded,
+        ChangesWhenCasemapped,
+        ChangesWhenLowercased,
+        ChangesWhenTitlecased,
+        ChangesWhenUppercased,
+        Lowercase,
+        Uppercase,
+    };
+    pub use crate::category::GeneralCategory;
+    pub use crate::common::{is_alphabetic, is_white_space, Alphabetic, WhiteSpace};
+    pub use crate::name::Name;
+    pub use crate::normal::CanonicalCombiningClass;
+    pub use crate::segment::{GraphemeClusterBreak, SentenceBreak, WordBreak};
+    pub use crate::unihan::{definition_of, mandarin_of, simplified_variant_of, traditional_variant_of};
+}
 
-/// The [Unicode version](https://www.unicode.org/versions/) of data
-pub use version::UNICODE_VERSION;
+#[cfg(not(unstable))]
+mod modules {
+    pub use super::version::UnicodeVersion;
+    /// The [Unicode version](https://www.unicode.org/versions/) of data
+    pub use super::version::UNICODE_VERSION;
+    pub use super::age::{Age, CharAge};
+    pub use super::bidi::{is_bidi_mirrored, BidiClass, CharBidiClass, StrBidiClass};
+    pub use super::case::{
+        changes_when_casefolded,
+        changes_when_casemapped,
+        changes_when_lowercased,
+        changes_when_titlecased,
+        changes_when_uppercased,
+        is_case_ignorable,
+        is_cased,
+        is_lowercase,
+        is_uppercase,
+        CaseIgnorable,
+        Cased,
+        ChangesWhenCasefolded,
+        ChangesWhenCasemapped,
+        ChangesWhenLowercased,
+        ChangesWhenTitlecased,
+        ChangesWhenUppercased,
+        Lowercase,
+        Uppercase,
+    };
+    pub use super::category::GeneralCategory;
+    pub use super::common::{is_alphabetic, is_white_space, Alphabetic, WhiteSpace};
+    pub use super::name::Name;
+    pub use super::normal::CanonicalCombiningClass;
+    pub use super::segment::{GraphemeClusterBreak, SentenceBreak, WordBreak};
+    pub use super::unihan::{definition_of, mandarin_of, simplified_variant_of, traditional_variant_of};
+}
 
-pub use age::{Age, CharAge};
 
-pub use bidi::{is_bidi_mirrored, BidiClass, CharBidiClass, StrBidiClass};
-
-pub use case::{
-    changes_when_casefolded,
-    changes_when_casemapped,
-    changes_when_lowercased,
-    changes_when_titlecased,
-    changes_when_uppercased,
-    is_case_ignorable,
-    is_cased,
-    is_lowercase,
-    is_uppercase,
-    CaseIgnorable,
-    Cased,
-    ChangesWhenCasefolded,
-    ChangesWhenCasemapped,
-    ChangesWhenLowercased,
-    ChangesWhenTitlecased,
-    ChangesWhenUppercased,
-    Lowercase,
-    Uppercase,
-};
-
-pub use category::GeneralCategory;
-
-pub use common::{is_alphabetic, is_white_space, Alphabetic, WhiteSpace};
-
-pub use name::Name;
-
-pub use normal::CanonicalCombiningClass;
-
-pub use segment::{GraphemeClusterBreak, SentenceBreak, WordBreak};
-
-pub use unihan::{definition_of, mandarin_of, simplified_variant_of, traditional_variant_of};
+pub use self::modules::*;
 
 mod pkg_info;
 pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/ucd/unihan/Cargo.toml
+++ b/unic/ucd/unihan/Cargo.toml
@@ -15,6 +15,15 @@ exclude = []
 unic-ucd-version = { path = "../version/", version = "0.7.0" }
 unic-char-property = { path = "../../char/property/", version = "0.7.0" }
 
+
+[features]
+default = []
+unstable = [
+    "unic-ucd-version/unstable",
+    "unic-char-property/unstable",
+]
+
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/unihan/src/lib.rs
+++ b/unic/ucd/unihan/src/lib.rs
@@ -17,15 +17,15 @@ extern crate unic_ucd_version;
 extern crate unic_char_property;
 
 mod readings;
-pub use readings::{definition_of, mandarin_of};
+pub use self::readings::{definition_of, mandarin_of};
 
 mod variants;
-pub use variants::{simplified_variant_of, traditional_variant_of};
+pub use self::variants::{simplified_variant_of, traditional_variant_of};
 
 use unic_ucd_version::UnicodeVersion;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 /// The [Unicode version](https://www.unicode.org/versions/) of data
 pub const UNICODE_VERSION: UnicodeVersion = include!("../tables/unicode_version.rsv");

--- a/unic/ucd/unihan/src/lib.rs
+++ b/unic/ucd/unihan/src/lib.rs
@@ -12,6 +12,7 @@
 #![no_std]
 #![forbid(future_incompatible, missing_debug_implementations, unconditional_recursion, unsafe_code)]
 #![deny(bad_style, unsafe_code, unused)]
+#![cfg_attr(unstable, feature("unstable"))]
 
 extern crate unic_ucd_version;
 extern crate unic_char_property;

--- a/unic/ucd/version/Cargo.toml
+++ b/unic/ucd/version/Cargo.toml
@@ -14,6 +14,12 @@ exclude = []
 [dependencies]
 unic-common = { path = "../../common/", version = "0.7.0" }
 
+[features]
+default = []
+unstable = [
+    "unic-common/unstable",
+]
+
 [badges]
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "behnam/rust-unic" }

--- a/unic/ucd/version/src/lib.rs
+++ b/unic/ucd/version/src/lib.rs
@@ -23,7 +23,7 @@ extern crate unic_common;
 pub use unic_common::version::UnicodeVersion;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use self::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod unicode_version;
-pub use unicode_version::UNICODE_VERSION;
+pub use self::unicode_version::UNICODE_VERSION;

--- a/unic/ucd/version/src/lib.rs
+++ b/unic/ucd/version/src/lib.rs
@@ -11,7 +11,7 @@
 #![no_std]
 #![forbid(bad_style, future_incompatible, missing_debug_implementations, missing_docs,
           unconditional_recursion, unsafe_code, unused)]
-
+#![cfg_attr(unstable, feature("unstable"))]
 //! # UNIC — UCD — Core
 //!
 //! A component of [`unic`: Unicode and Internationalization Crates for Rust](/unic/).


### PR DESCRIPTION
1. upgrade regex to `1.0`.
2. fix mod path on nightly version.
3. fix test unicode version ( https://github.com/eyeplum/rust-unic/pull/1/commits/b9677f0eea63dafdcf6ec85ed2b6cad68b7cc8f9 )


